### PR TITLE
Fixes EntityListItem label resizing.

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -268,7 +268,6 @@ _global_script_class_icons={
 
 config/name="crawl"
 run/main_scene="res://src/Main.tscn"
-config/icon="res://icon.png"
 
 [autoload]
 

--- a/src/DebugSettings.gd
+++ b/src/DebugSettings.gd
@@ -14,6 +14,9 @@ func _ready() -> void:
 	globals.debug_settings = self
 	events.connect("game_ready", self, "_on_game_ready")
 
+func _on_game_ready():
+	pass
+
 func set_show_mouse_pos(enabled: bool) -> void:
 	if !globals.debug_mouse_pos:
 		return

--- a/src/Main.tscn
+++ b/src/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=33 format=2]
+[gd_scene load_steps=32 format=2]
 
 [ext_resource path="res://src/ui/Console.gd" type="Script" id=1]
 [ext_resource path="res://src/DebugGrid.gd" type="Script" id=2]
@@ -38,14 +38,11 @@ border_width_top = 1
 [sub_resource type="StyleBoxFlat" id=3]
 bg_color = Color( 0, 0, 0, 1 )
 
-[sub_resource type="StyleBoxFlat" id=4]
-bg_color = Color( 0, 0, 0, 1 )
-
-[sub_resource type="DynamicFont" id=5]
+[sub_resource type="DynamicFont" id=4]
 size = 96
 font_data = ExtResource( 3 )
 
-[sub_resource type="DynamicFont" id=6]
+[sub_resource type="DynamicFont" id=5]
 size = 64
 font_data = ExtResource( 3 )
 
@@ -60,142 +57,10 @@ rng_seed = "38f44f3b"
 
 [node name="UI" type="CanvasLayer" parent="."]
 
-[node name="HUDBackground" type="Control" parent="UI"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="PanelLeft" type="Panel" parent="UI/HUDBackground"]
-anchor_bottom = 1.0
-margin_right = 250.0
-margin_bottom = -200.0
-custom_styles/panel = SubResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="PanelBottom" type="Panel" parent="UI/HUDBackground"]
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 250.0
-margin_top = -200.0
-custom_styles/panel = SubResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="PanelCorner" type="Panel" parent="UI/HUDBackground"]
-anchor_top = 1.0
-anchor_bottom = 1.0
-margin_top = -200.0
-margin_right = 250.0
-custom_styles/panel = SubResource( 3 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="LeftUI" type="MarginContainer" parent="UI"]
-anchor_bottom = 1.0
-margin_right = 250.0
-custom_constants/margin_top = 10
-custom_constants/margin_left = 10
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="VBoxContainer" type="VBoxContainer" parent="UI/LeftUI"]
-margin_left = 10.0
-margin_top = 10.0
-margin_right = 250.0
-margin_bottom = 768.0
-theme = ExtResource( 13 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="StatsUI" type="MarginContainer" parent="UI/LeftUI/VBoxContainer"]
-margin_right = 240.0
-margin_bottom = 29.0
-custom_constants/margin_top = 0
-custom_constants/margin_left = 10
-script = ExtResource( 20 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="VBoxContainer" type="VBoxContainer" parent="UI/LeftUI/VBoxContainer/StatsUI"]
-margin_left = 10.0
-margin_right = 230.0
-margin_bottom = 19.0
-custom_constants/separation = 0
-
-[node name="HP" type="Label" parent="UI/LeftUI/VBoxContainer/StatsUI/VBoxContainer"]
-margin_right = 220.0
-margin_bottom = 19.0
-theme = ExtResource( 7 )
-custom_colors/font_outline_modulate = Color( 0.756863, 0.0980392, 0.0980392, 1 )
-custom_constants/shadow_offset_x = 2
-custom_constants/line_spacing = 0
-custom_constants/shadow_offset_y = 1
-custom_constants/shadow_as_outline = 4
-text = "HP: 0 / 0"
-
-[node name="NPCList" type="Control" parent="UI/LeftUI/VBoxContainer"]
-margin_top = 39.0
-margin_right = 240.0
-margin_bottom = 39.0
-script = ExtResource( 23 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="VBoxContainer" type="VBoxContainer" parent="UI/LeftUI/VBoxContainer/NPCList"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="EntityListItem" parent="UI/LeftUI/VBoxContainer/NPCList/VBoxContainer" instance=ExtResource( 12 )]
-margin_right = 240.0
-margin_bottom = 95.0
-rect_min_size = Vector2( 0, 95 )
-
-[node name="Shortcut" parent="UI/LeftUI/VBoxContainer/NPCList/VBoxContainer/EntityListItem/HBoxContainer" index="0"]
-visible = false
-margin_right = 0.0
-text = ""
-
-[node name="TextureRect" parent="UI/LeftUI/VBoxContainer/NPCList/VBoxContainer/EntityListItem/HBoxContainer" index="1"]
-margin_left = 0.0
-margin_right = 32.0
-
-[node name="EntityListItem2" parent="UI/LeftUI/VBoxContainer/NPCList/VBoxContainer" instance=ExtResource( 12 )]
-margin_top = 105.0
-margin_right = 240.0
-margin_bottom = 137.0
-rect_min_size = Vector2( 0, 32 )
-
-[node name="Shortcut" parent="UI/LeftUI/VBoxContainer/NPCList/VBoxContainer/EntityListItem2/HBoxContainer" index="0"]
-visible = false
-margin_right = 0.0
-text = ""
-
-[node name="TextureRect" parent="UI/LeftUI/VBoxContainer/NPCList/VBoxContainer/EntityListItem2/HBoxContainer" index="1"]
-margin_left = 0.0
-margin_right = 32.0
-
-[node name="DisplayName" parent="UI/LeftUI/VBoxContainer/NPCList/VBoxContainer/EntityListItem2" index="1"]
-margin_left = 32.0
-margin_right = 240.0
-rect_min_size = Vector2( -1, 32 )
-
 [node name="Debug" type="Control" parent="UI"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+mouse_filter = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -213,12 +78,123 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Console" type="RichTextLabel" parent="UI"]
+[node name="HSplitContainer" type="HSplitContainer" parent="UI"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_bottom = -200.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="PanelLeft" type="Panel" parent="UI/HSplitContainer"]
+margin_right = 250.0
+margin_bottom = 568.0
+rect_min_size = Vector2( 250, 0 )
+custom_styles/panel = SubResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="LeftUI" type="MarginContainer" parent="UI/HSplitContainer/PanelLeft"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_right = 10
+custom_constants/margin_top = 10
+custom_constants/margin_left = 10
+custom_constants/margin_bottom = 10
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="VBoxContainer" type="VBoxContainer" parent="UI/HSplitContainer/PanelLeft/LeftUI"]
+margin_left = 10.0
+margin_top = 10.0
+margin_right = 240.0
+margin_bottom = 558.0
+theme = ExtResource( 13 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="StatsUI" type="MarginContainer" parent="UI/HSplitContainer/PanelLeft/LeftUI/VBoxContainer"]
+margin_right = 230.0
+margin_bottom = 29.0
+custom_constants/margin_right = 0
+custom_constants/margin_top = 0
+custom_constants/margin_left = 0
+script = ExtResource( 20 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="VBoxContainer" type="VBoxContainer" parent="UI/HSplitContainer/PanelLeft/LeftUI/VBoxContainer/StatsUI"]
+margin_right = 230.0
+margin_bottom = 19.0
+custom_constants/separation = 0
+
+[node name="HP" type="Label" parent="UI/HSplitContainer/PanelLeft/LeftUI/VBoxContainer/StatsUI/VBoxContainer"]
+margin_right = 230.0
+margin_bottom = 19.0
+theme = ExtResource( 7 )
+custom_colors/font_outline_modulate = Color( 0.756863, 0.0980392, 0.0980392, 1 )
+custom_constants/shadow_offset_x = 2
+custom_constants/line_spacing = 0
+custom_constants/shadow_offset_y = 1
+custom_constants/shadow_as_outline = 4
+text = "HP: 0 / 0"
+autowrap = true
+
+[node name="NPCList" type="Control" parent="UI/HSplitContainer/PanelLeft/LeftUI/VBoxContainer"]
+margin_top = 39.0
+margin_right = 230.0
+margin_bottom = 39.0
+script = ExtResource( 23 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="VBoxContainer" type="VBoxContainer" parent="UI/HSplitContainer/PanelLeft/LeftUI/VBoxContainer/NPCList"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="EntityListItem" parent="UI/HSplitContainer/PanelLeft/LeftUI/VBoxContainer/NPCList/VBoxContainer" instance=ExtResource( 12 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 230.0
+margin_bottom = 95.0
+rect_min_size = Vector2( 0, 95 )
+
+[node name="EntityListItem2" parent="UI/HSplitContainer/PanelLeft/LeftUI/VBoxContainer/NPCList/VBoxContainer" instance=ExtResource( 12 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 105.0
+margin_right = 230.0
+margin_bottom = 124.0
+
+[node name="PanelCenter" type="Control" parent="UI/HSplitContainer"]
+margin_left = 262.0
+margin_right = 1024.0
+margin_bottom = 568.0
+
+[node name="PanelBottom" type="Panel" parent="UI"]
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
+margin_top = -200.0
+custom_styles/panel = SubResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Console" type="RichTextLabel" parent="UI/PanelBottom"]
+anchor_right = 1.0
+anchor_bottom = 1.0
 margin_left = 10.0
-margin_top = -190.0
+margin_top = 10.0
+margin_right = -10.0
 margin_bottom = -10.0
 theme = ExtResource( 7 )
 bbcode_text = "asdfzxcvasdf"
@@ -243,7 +219,7 @@ margin_right = -590.0
 visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
-custom_styles/panel = SubResource( 4 )
+custom_styles/panel = SubResource( 3 )
 script = ExtResource( 25 )
 
 [node name="MarginContainer" type="MarginContainer" parent="UI/DeadScreen"]
@@ -263,7 +239,7 @@ margin_bottom = 151.0
 [node name="Label" type="Label" parent="UI/DeadScreen/MarginContainer/VBoxContainer"]
 margin_right = 540.0
 margin_bottom = 88.0
-custom_fonts/font = SubResource( 5 )
+custom_fonts/font = SubResource( 4 )
 custom_colors/font_color = Color( 0.866667, 0.564706, 0.564706, 1 )
 custom_colors/font_outline_modulate = Color( 0, 0, 0, 1 )
 text = "You are dead"
@@ -273,7 +249,7 @@ align = 1
 margin_top = 92.0
 margin_right = 540.0
 margin_bottom = 151.0
-custom_fonts/font = SubResource( 6 )
+custom_fonts/font = SubResource( 5 )
 custom_colors/font_color = Color( 0.866667, 0.564706, 0.564706, 1 )
 custom_colors/font_outline_modulate = Color( 0, 0, 0, 1 )
 text = "Restart? [Y/n]"
@@ -374,7 +350,3 @@ script = ExtResource( 5 )
 script = ExtResource( 9 )
 max_size = 12.0
 min_size = 8.0
-
-[editable path="UI/LeftUI/VBoxContainer/NPCList/VBoxContainer/EntityListItem"]
-
-[editable path="UI/LeftUI/VBoxContainer/NPCList/VBoxContainer/EntityListItem2"]

--- a/src/ui/EntityListItem.tscn
+++ b/src/ui/EntityListItem.tscn
@@ -1,45 +1,84 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://assets/sprites/items/Item__00.png" type="Texture" id=1]
 [ext_resource path="res://src/ui/EntityListItem.gd" type="Script" id=2]
-[ext_resource path="res://overlay_theme.tres" type="Theme" id=3]
 
 [node name="EntityListItem" type="Button"]
-margin_right = 320.0
-margin_bottom = 32.0
-theme = ExtResource( 3 )
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_horizontal = 3
 script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="HBoxContainer" type="HBoxContainer" parent="."]
-size_flags_vertical = 3
-custom_constants/separation = 20
+[node name="HBox" type="HBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/separation = 14
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Shortcut" type="Label" parent="HBoxContainer"]
-margin_right = 29.0
-margin_bottom = 32.0
-size_flags_vertical = 3
-text = "(a)"
+[node name="ShortcutMargin" type="MarginContainer" parent="HBox"]
+margin_right = 21.0
+margin_bottom = 30.0
+mouse_filter = 2
+size_flags_vertical = 0
+custom_constants/margin_right = 3
+custom_constants/margin_top = 8
+custom_constants/margin_left = 3
+custom_constants/margin_bottom = 8
 
-[node name="TextureRect" type="TextureRect" parent="HBoxContainer"]
-margin_left = 49.0
-margin_right = 81.0
-margin_bottom = 32.0
+[node name="Shortcut" type="Label" parent="HBox/ShortcutMargin"]
+margin_left = 3.0
+margin_top = 8.0
+margin_right = 18.0
+margin_bottom = 22.0
+size_flags_vertical = 0
+text = "[a]"
+
+[node name="ImageMargin" type="MarginContainer" parent="HBox"]
+margin_left = 35.0
+margin_right = 73.0
+margin_bottom = 38.0
+mouse_filter = 1
+size_flags_vertical = 0
+custom_constants/margin_right = 3
+custom_constants/margin_top = 3
+custom_constants/margin_left = 3
+custom_constants/margin_bottom = 3
+
+[node name="Image" type="TextureRect" parent="HBox/ImageMargin"]
+margin_left = 3.0
+margin_top = 3.0
+margin_right = 35.0
+margin_bottom = 35.0
 rect_min_size = Vector2( 32, 32 )
-size_flags_vertical = 3
+size_flags_vertical = 0
 size_flags_stretch_ratio = 10.0
 texture = ExtResource( 1 )
-stretch_mode = 6
+stretch_mode = 5
 
-[node name="DisplayName" type="Label" parent="."]
-anchor_bottom = 1.0
-margin_left = 101.0
-margin_right = 285.0
+[node name="NameMargin" type="MarginContainer" parent="HBox"]
+margin_left = 87.0
+margin_right = 1024.0
+margin_bottom = 30.0
+mouse_filter = 2
+size_flags_horizontal = 3
+size_flags_vertical = 0
+custom_constants/margin_right = 3
+custom_constants/margin_top = 8
+custom_constants/margin_left = 3
+custom_constants/margin_bottom = 8
+
+[node name="Name" type="Label" parent="HBox/NameMargin"]
+margin_left = 3.0
+margin_top = 8.0
+margin_right = 934.0
+margin_bottom = 22.0
+size_flags_horizontal = 3
+size_flags_vertical = 0
 text = "why why why why why"
 autowrap = true
 __meta__ = {


### PR DESCRIPTION
Wraps EntityListItem children in MarginContainers and adds deferred label size calculations. Also wraps LeftUI in HSplitContainer.

# Text wraps nicely in narrow left panel
![Screen Shot 2020-02-25 at 11 44 33 PM](https://user-images.githubusercontent.com/2592431/75314192-0b06f780-582d-11ea-8cd6-df29282d0c02.jpg)

# Smooth reflows when left panel is resized
![Screen Shot 2020-02-25 at 11 44 44 PM](https://user-images.githubusercontent.com/2592431/75314224-2114b800-582d-11ea-8cd6-1996dcaa0a71.jpg)

# Item lists still work as expected in dialogs
![Screen Shot 2020-02-25 at 11 46 15 PM](https://user-images.githubusercontent.com/2592431/75314245-2ffb6a80-582d-11ea-835c-c67e6286a9a0.jpg)

